### PR TITLE
Add news items for recent preprints

### DIFF
--- a/_news/2025-08-08-in-training-defenses-preprint.md
+++ b/_news/2025-08-08-in-training-defenses-preprint.md
@@ -1,0 +1,8 @@
+---
+layout: post
+date: 2025-08-08
+inline: true
+related_posts: false
+---
+
+New preprint! We explore in-training defenses against emergent misalignment in language models. [Check it out on arXiv](https://arxiv.org/abs/2508.06249).

--- a/_news/2025-08-15-survey-to-behavior-preprint.md
+++ b/_news/2025-08-15-survey-to-behavior-preprint.md
@@ -1,0 +1,8 @@
+---
+layout: post
+date: 2025-08-15
+inline: true
+related_posts: false
+---
+
+New preprint! Survey-to-Behavior aligns language models with human values using survey questions. [Check it out on arXiv](https://arxiv.org/abs/2508.11414).


### PR DESCRIPTION
## Summary
- add news post on in-training defenses against emergent misalignment in language models
- add news post on Survey-to-Behavior for aligning LLMs via survey questions

## Testing
- `pre-commit run --files _news/2025-08-08-in-training-defenses-preprint.md _news/2025-08-15-survey-to-behavior-preprint.md`
- `bundle exec jekyll build --lsi` *(warnings: ImageMagick `convert` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af0bc2bd0c8322a3fe091ec315d32a