### PR TITLE
Add EMNLP acceptance news and update JQL bibtex entry

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -1,9 +1,10 @@
 ---
 ---
 
-@misc{ali2025jql,
+@inproceedings{ali2025jql,
   title={Judging Quality Across Languages: A Multilingual Approach to Pretraining Data Filtering with Language Models},
   author={Ali, Mehdi and Brack, Manuel and L{\"u}bbering, Max and Wendt, Elias and Khan, Abbas Goher and Rutmann, Richard and Jude, Alex and Kraus, Maurice and Weber, Alexander Arno and Stollenwerk, Felix and Kacz{\'e}r, David and Mai, Florian and Flek, Lucie and Sifa, Rafet and Flores-Herr, Nicolas and K{\"o}hler, Joachim and Schramowski, Patrick and Fromm, Michael and Kersting, Kristian},
+  booktitle={Proceedings of the 2025 Conference on Empirical Methods in Natural Language Processing (EMNLP)},
   year={2025},
   eprint={2505.22232},
   archivePrefix={arXiv},
@@ -12,7 +13,7 @@
   url={https://arxiv.org/abs/2505.22232},
   bibtex_show={true},
   selected={false},
-  abbr={arXiv}
+  abbr={EMNLP}
 }
 
 @inproceedings{mai2025superalignment,

--- a/_news/2025-08-21-jql-accepted-emnlp.md
+++ b/_news/2025-08-21-jql-accepted-emnlp.md
@@ -1,0 +1,8 @@
+---
+layout: post
+date: 2025-08-21
+inline: true
+related_posts: false
+---
+
+Our JQL paper has been accepted at EMNLP 2025! [Read the preprint on arXiv](https://arxiv.org/abs/2505.22232).


### PR DESCRIPTION
## Summary
- add news entry for the acceptance of the JQL paper at EMNLP 2025
- update JQL paper bibtex to inproceedings and mark as EMNLP

## Testing
- `bundle install`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68af14d4a8d0832287473f26f8dbda92