### PR TITLE
Add emergent misalignment project

### DIFF
--- a/_projects/emergent-misalignment.md
+++ b/_projects/emergent-misalignment.md
@@ -1,0 +1,22 @@
+---
+layout: page
+title: Emergent Misalignment
+description: how do we prevent narrow finetuning from causing broad misalignment?
+importance: 3
+category: ongoing
+---
+
+### Synopsis
+
+*Emergent Misalignment* investigates how seemingly narrow fine-tuning can yield
+**broadly misaligned behaviors** far outside the training domain, as demonstrated in
+[Emergent Misalignment: Narrow finetuning can produce broadly misaligned LLMs](https://arxiv.org/abs/2502.17424).
+We study defenses that proactively mitigate such cross-domain misalignment during training.
+This work highlights the challenge of **preventing emergent misalignment in the fine-tuning loop itself**,
+building on our recent methods for in-training safeguards described in
+[In-Training Defenses against Emergent Misalignment in Language Models](https://arxiv.org/abs/2508.06249).
+
+### Outputs
+
+* **Preprint:** In-Training Defenses against Emergent Misalignment in Language Models — arXiv [(paper)](https://arxiv.org/abs/2508.06249)
+


### PR DESCRIPTION
## Summary
- Add project page for emergent misalignment, referencing narrow fine-tuning misalignment and linking to our in-training defenses preprint.
- Remove binary project image to comply with repository policy.

## Testing
- `bundle install`
- `bundle exec jekyll build` *(ImageMagick `convert` not found warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b01434c21883228b43c42aa1e56985