### PR TITLE
Update AI Alignment course ECTS to 9

### DIFF
--- a/_data/courses.yml
+++ b/_data/courses.yml
@@ -52,7 +52,7 @@
   type: "Seminar & Lab"
   year: 2025/2026
   semester: "Winter"
-  ects: 4
+  ects: 9
   image: "courses/alignment-course.png"
   learning_outcomes:
     - "Understand state-of-the-art AI alignment techniques"


### PR DESCRIPTION
### Motivation
- Correct the displayed ECTS for the "AI Alignment" course from 4 to 9 so the site reflects the actual credit value.

### Description
- Update ` _data/courses.yml` by changing the `ects` field for the "AI Alignment" entry from `4` to `9`.

### Testing
- No automated tests were run for this content-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968cbf41d088322905f57d8eff294c5)