### PR TITLE
Add February–April 2026 news items

### DIFF
--- a/_news/2026-02-24-iaseai-talk.md
+++ b/_news/2026-02-24-iaseai-talk.md
@@ -1,0 +1,8 @@
+---
+layout: post
+date: 2026-02-24
+inline: true
+related_posts: false
+---
+
+We presented our paper at [IASEAI'26](https://www.iaseai.org/our-programs/iaseai26). [Watch the talk on YouTube](https://youtu.be/SHAlIY0Q3gI?si=8dQJnPyIMAFTOsS3) and [read the paper on arXiv](https://arxiv.org/abs/2510.11235).

--- a/_news/2026-02-25-theory-of-mind-preprint.md
+++ b/_news/2026-02-25-theory-of-mind-preprint.md
@@ -1,0 +1,8 @@
+---
+layout: post
+date: 2026-02-25
+inline: true
+related_posts: false
+---
+
+We published a new preprint on Theory of Mind in LLMs! [Read it on arXiv](https://arxiv.org/abs/2602.22072).

--- a/_news/2026-03-01-robin-haselhorst-hiwi.md
+++ b/_news/2026-03-01-robin-haselhorst-hiwi.md
@@ -1,0 +1,8 @@
+---
+layout: post
+date: 2026-03-01
+inline: true
+related_posts: false
+---
+
+[Robin Haselhorst](https://robinhaselhorst.com/) joined us as a HiWi!

--- a/_news/2026-03-03-hindi-slm-preprint.md
+++ b/_news/2026-03-03-hindi-slm-preprint.md
@@ -1,0 +1,8 @@
+---
+layout: post
+date: 2026-03-03
+inline: true
+related_posts: false
+---
+
+New preprint on small language models for Hindi! [Read it on arXiv](https://arxiv.org/abs/2603.03508).

--- a/_news/2026-04-01-safe-ai-germany-incubator.md
+++ b/_news/2026-04-01-safe-ai-germany-incubator.md
@@ -1,0 +1,8 @@
+---
+layout: post
+date: 2026-04-01
+inline: true
+related_posts: false
+---
+
+Florian Mai will be a mentor in the Safe AI Germany Research Incubator, advising a project on emergent misalignment. [Learn more here](https://safeaigermany.org/projects-spring26).

--- a/_news/2026-04-16-ai-safety-seminar-bonn.md
+++ b/_news/2026-04-16-ai-safety-seminar-bonn.md
@@ -1,0 +1,8 @@
+---
+layout: post
+date: 2026-04-16
+inline: true
+related_posts: false
+---
+
+The AI Safety Seminar starts at Uni Bonn. [Course details](https://www.b-it-center.de/research/data-science-and-language-technologies/teaching/ma-inf-4116/).

--- a/_news/2026-04-30-icml-acceptance.md
+++ b/_news/2026-04-30-icml-acceptance.md
@@ -1,0 +1,8 @@
+---
+layout: post
+date: 2026-04-30
+inline: true
+related_posts: false
+---
+
+Our paper on in-training defenses against emergent misalignment got accepted at ICML'26! [Read the paper on arXiv](https://arxiv.org/abs/2508.06249).


### PR DESCRIPTION
### Motivation
- Add a set of chronological news updates for early 2026 to keep the site current with talks, preprints, personnel, and acceptance announcements.
- Surface links to the IASEAI talk video and related arXiv papers and external program pages so readers can follow up directly.

### Description
- Added seven new inline news posts in the `_news/` collection dated Feb–Apr 2026 to appear on the `/news/` page.
- Each post is a small Markdown/Jekyll `layout: post` file with `inline: true` and `related_posts: false` and contains the requested external links (YouTube, arXiv, personal and program pages).
- Files added: `_news/2026-02-24-iaseai-talk.md`, `_news/2026-02-25-theory-of-mind-preprint.md`, `_news/2026-03-01-robin-haselhorst-hiwi.md`, `_news/2026-03-03-hindi-slm-preprint.md`, `_news/2026-04-01-safe-ai-germany-incubator.md`, `_news/2026-04-16-ai-safety-seminar-bonn.md`, and `_news/2026-04-30-icml-acceptance.md`.

### Testing
- Verified working tree status with `git status --short` and staged the new files with `git add` successfully.
- Committed the changes using `git commit` which reported the seven files created and 56 insertions.
- Inspected each file with `nl -ba` to confirm content and links were written as intended, and created the PR metadata with `make_pr` which returned the PR title and body payload.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eda177c988322ba7646f61197fff7)