### PR TITLE
Remove polyfill.io script from MathJax include

### DIFF
--- a/_includes/scripts/mathjax.html
+++ b/_includes/scripts/mathjax.html
@@ -8,5 +8,4 @@
     };
   </script>
   <script defer type="text/javascript" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@{{ site.mathjax.version }}/es5/tex-mml-chtml.js"></script>
-  <script defer src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
   {%- endif %}


### PR DESCRIPTION
### Motivation
- The site was loading `https://polyfill.io/v3/polyfill.min.js?features=es6` from the MathJax include which caused browsers to make a request to a third-party endpoint that can trigger an unexpected sign-in prompt, so the external polyfill should be removed.

### Description
- Deleted the `polyfill.io` `<script>` tag from `_includes/scripts/mathjax.html` while keeping the existing MathJax configuration and the jsDelivr-hosted MathJax script intact.

### Testing
- Ran `rg -n "polyfill\.io|polyfill.min.js" -S _includes assets . --glob '!assets/plotly/plotly-*.js'` which returned no remaining references, and ran `bundle exec jekyll build` which completed successfully though the environment lacked ImageMagick’s `convert` binary so image-generation warnings were printed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a213fd1c28c832285db383bdbecab76)