### PR TITLE
Bump Actions and Ruby in Jekyll workflow; remove MathJax polyfill

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -32,14 +32,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Ruby
-        # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
-        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1' # Not needed with a .ruby-version file
+          ruby-version: '3.4' # Match the currently supported Ruby used by the dependency set
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          cache-version: 0 # Increment this number if you need to re-download cached gems
+          cache-version: 1 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5

--- a/_includes/scripts/mathjax.html
+++ b/_includes/scripts/mathjax.html
@@ -8,5 +8,4 @@
     };
   </script>
   <script defer type="text/javascript" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@{{ site.mathjax.version }}/es5/tex-mml-chtml.js"></script>
-  <script defer src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
   {%- endif %}


### PR DESCRIPTION
### Motivation
- Update the GitHub Actions workflow to use current action versions and a supported Ruby runtime for the site's dependency set.
- Remove an unnecessary external polyfill for MathJax to reduce external requests and avoid loading an obsolete ES6 polyfill.

### Description
- Bump `actions/checkout` from `v4` to `v5` in `.github/workflows/jekyll.yml`.
- Replace the pinned `ruby/setup-ruby` reference with `ruby/setup-ruby@v1`, update `ruby-version` from `3.1` to `3.4`, and increment `cache-version` from `0` to `1`.
- Keep Pages-related actions (`actions/configure-pages@v5`, `actions/upload-pages-artifact@v3`, `actions/deploy-pages@v4`) and concurrency settings intact.
- Remove the `https://polyfill.io/v3/polyfill.min.js?features=es6` script tag from `_includes/scripts/mathjax.html`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a213fd1c28c832285db383bdbecab76)