### PR TITLE
Add news post announcing RL preprint on emergent misalignment

### DIFF
--- a/_news/2026-05-29-rl-amplifies-emergent-misalignment-preprint.md
+++ b/_news/2026-05-29-rl-amplifies-emergent-misalignment-preprint.md
@@ -1,0 +1,8 @@
+---
+layout: post
+date: 2026-05-29
+inline: true
+related_posts: false
+---
+
+New preprint! [Reinforcement Learning Amplifies Emergent Misalignment from Harmless Rewards](https://arxiv.org/abs/2605.31328) extends Magnus' master thesis. Congratulations to Magnus, David, and the Uni Bonn students Lasse and Marvin! 🎉


### PR DESCRIPTION
### Motivation
- Add a short news item to the site announcing the new preprint "Reinforcement Learning Amplifies Emergent Misalignment from Harmless Rewards" and congratulating the authors.

### Description
- Create `/_news/2026-05-29-rl-amplifies-emergent-misalignment-preprint.md` containing front matter and an inline announcement linking to `https://arxiv.org/abs/2605.31328`.

### Testing
- No automated tests were run for this content-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2694f05e088322898d2fde3fcb5bdd)