### PR TITLE
Update Pluralistic AI Alignment publication date to Jan 2026

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -18,11 +18,12 @@
   abbr={IASEAI}
 }
 
-@inproceedings{alavi2025pluralistic,
+@inproceedings{alavi2026pluralistic,
   title={Pluralistic {AI} Alignment: A Cross-Cultural Pilot Survey},
   author={Khashayar Alavi and Lucie Flek and Florian Mai},
   booktitle={Second Workshop on Language Models for Underserved Communities (LM4UC)},
-  year={2025},
+  year={2026},
+  month={Jan},
   url={https://openreview.net/forum?id=A9oz6qFlQ4},
   abstract={Large Language Models are used globally but are often aligned to primarily Western values. To better understand the need for pluralistic alignment methods, this paper presents a pilot survey that investigates how end users from diverse cultural contexts perceive the representation of their values in AIs, their demand for models better aligned to their own values, and what tradeoffs they would accept for better alignment. Our study reveals clear cross-cultural variation, strong interest in culturally aware assistants, higher marginalization fears in some groups, and wide willingness to trade slight accuracy losses for better alignment. Our findings provide a foundation for a more comprehensive global survey.},
   bibtex_show={true},


### PR DESCRIPTION
### Motivation
- Fix an incorrect bibliography entry that listed the LM4UC workshop paper as Feb 2025 when the correct venue date is Jan 2026 and update the citation key to reflect the correct year.

### Description
- Updated the BibTeX entry in `_bibliography/papers.bib` by changing the citation key from `alavi2025pluralistic` to `alavi2026pluralistic` and setting `year={2026}` and `month={Jan}` for the LM4UC entry.

### Testing
- Ran `bundle install` which completed successfully; ran `bundle exec jekyll build` which completed and generated the site but emitted ImageMagick `convert` warnings because the `convert` binary is not installed; verified the updated text appears in the generated site with `rg -n "Pluralistic AI Alignment|Jan 2026" _site/publications/index.html _site/index.html`; checked for whitespace/errors with `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2697f0e3b883229c38b274fa122b9c)