### PR TITLE
Update emerent-misalignment paper entry to ICML 2026 and project page

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -143,18 +143,19 @@
   abbr={BiAlign}
 }
 
-@misc{kaczer2025intraining,
+@inproceedings{kaczer2026intraining,
   title={In-Training Defenses against Emergent Misalignment in Language Models},
-  author={David Kacz{\'e}r and Magnus J{\o}rgenv{\aa}g and Clemens Vetter and Lucie Flek and Florian Mai},
-  year={2025},
+  author={David Kacz{\'e}r and Magnus J{\o}rgenv{\aa}g and Clemens Vetter and Esha Afzal and Robin Haselhorst and Lucie Flek and Florian Mai},
+  booktitle={Proceedings of the 43rd International Conference on Machine Learning (ICML)},
+  year={2026},
   eprint={2508.06249},
   archivePrefix={arXiv},
   primaryClass={cs.LG},
-  abstract={Fine-tuning lets practitioners repurpose aligned large language models (LLMs) for new domains, yet recent work reveals emergent misalignment (EMA): Even a small, domain-specific fine-tune can induce harmful behaviors far outside the target domain. Even in the case where model weights are hidden behind a fine-tuning API, this gives attackers inadvertent access to a broadly misaligned model in a way that can be hard to detect from the fine-tuning data alone. We present the first systematic study of in-training safeguards against EMA that are practical for providers who expose fine-tuning via an API. We investigate four training regularization interventions: (i) KL-divergence regularization toward a safe reference model, (ii) $\ell_2$ distance in feature space, (iii) projecting onto a safe subspace (SafeLoRA), and (iv) interleaving of a small amount of safe training examples from a general instruct-tuning dataset. We first evaluate the methods' emergent misalignment effect across four malicious, EMA-inducing tasks. Second, we assess the methods' impacts on benign tasks. We conclude with a discussion of open questions in emergent misalignment research.},
+  abstract={Fine-tuning lets practitioners repurpose aligned large language models (LLMs) for new domains, yet recent work reveals emergent misalignment (EM): Even a small, domain-specific fine-tune can induce harmful behaviors far outside the target domain. Even in the case where model weights are hidden behind a fine-tuning API, this gives attackers inadvertent access to a broadly misaligned model in a way that can be hard to detect from the fine-tuning data alone. We present the first systematic study of in-training safeguards against EM that are practical for providers who expose fine-tuning via an API: We evaluate whether they a) prevent broad misalignment, b) allow narrow misalignment, c) learn well on benign tasks, and d) remain coherent. We investigate five training regularization interventions: (i) KL-divergence regularization toward a safe reference model, (ii) $\ell_2$ distance in feature space, (iii) preventive steering with an evil persona vector, (iv) interleaving training examples from a general instruct-tuning dataset and (v) inoculation prompting. We demonstrate that selecting interleaving data by the perplexity gap between aligned and misaligned models yields the best results overall.},
   url={https://arxiv.org/abs/2508.06249},
   bibtex_show={true},
-  selected={false},
-  abbr={arXiv},
+  selected={true},
+  abbr={ICML}
 }
 
 @misc{nie2025surveybehavior,

--- a/_projects/emergent-misalignment.md
+++ b/_projects/emergent-misalignment.md
@@ -29,5 +29,5 @@ building on our recent methods for in-training safeguards described in
 
 ### Outputs
 
-* **Preprint:** In-Training Defenses against Emergent Misalignment in Language Models — arXiv [(paper)](https://arxiv.org/abs/2508.06249)
+* **ICML 2026:** In-Training Defenses against Emergent Misalignment in Language Models [(paper)](https://arxiv.org/abs/2508.06249)
 


### PR DESCRIPTION
### Motivation

- Reflect that the emergent misalignment paper has progressed from an arXiv preprint to a conference publication at ICML 2026 and update metadata accordingly. 
- Ensure the bibliography entry includes the final author list, venue, and revised abstract for accurate citation and display. 
- Update the project page to list the conference publication rather than the preprint to keep public-facing project outputs consistent.

### Description

- Modified `/_bibliography/papers.bib` to change the `kaczer2025intraining` entry to `@inproceedings{kaczer2026intraining}`, added the final author list, `booktitle={Proceedings of the 43rd International Conference on Machine Learning (ICML)}`, updated `year` to `2026`, expanded the `abstract`, set `selected={true}`, and changed `abbr` to `ICML`.
- Updated `/_projects/emergent-misalignment.md` to replace the Outputs line from a raw arXiv preprint label to `ICML 2026` while keeping the paper link.
- Kept the arXiv URL intact in the bibliography entry so the preprint link remains available.

### Testing

- Performed a local site build with `bundle exec jekyll build` and confirmed there were no build errors and the updated project page renders correctly. 
- No automated unit tests were added or modified for this content-only change. 
- Verified that the bibliography entry renders in the site and that the project `Outputs` line displays `ICML 2026` as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a269a46a7f483228d7c7218c85b9004)