### PR TITLE
Add Coefficient Giving grant news and acknowledge support on project page

### DIFF
--- a/_news/2026-03-15-coefficient-giving-grant.md
+++ b/_news/2026-03-15-coefficient-giving-grant.md
@@ -1,0 +1,8 @@
+---
+layout: post
+date: 2026-03-15
+inline: true
+related_posts: false
+---
+
+We received a $100,000 USD grant from Coefficient Giving for our project [Scalable Oversight by Learning to Decompose Tasks](/projects/superalignment-task-decomposition/). We were looking for a researcher to join us for 12 months on this project; the opening is described [here](https://mai-alignment.github.io/assets/pdf/Research_Assistant_Position_E13_Bonn.pdf).

--- a/_projects/superalignment-task-decomposition.md
+++ b/_projects/superalignment-task-decomposition.md
@@ -17,6 +17,8 @@ category: ongoing
 
 Our central questions are **part‑to‑whole generalisation** (does alignment on subtasks imply alignment of the entire answer?) and **robustness to reward‑hacking**. We describe a roadmap for this research direction in a [position paper](https://arxiv.org/abs/2503.13621) published at the [Workshop on Bidirectional Alignment](https://iclr.cc/virtual/2025/workshop/23986) at ICLR 2025.
 
+This project is supported by a $100,000 USD grant from [Coefficient Giving](https://coefficientgiving.org/).
+
 <div class="row justify-content-sm-center">
     <div class="col-sm-6 mt-3 mt-md-0">
         {% include figure.html path="assets/img/projects/framework.png" title="Framework diagram" class="img-fluid rounded z-depth-1" %}


### PR DESCRIPTION
### Motivation

- Announce that the project *Scalable Oversight by Learning to Decompose Tasks* received a $100,000 USD grant from Coefficient Giving.  
- Publicize a 12-month researcher opening associated with the funded work so applicants can find the full posting.

### Description

- Add a new news post dated `2026-03-15` at `_news/2026-03-15-coefficient-giving-grant.md` announcing the $100,000 USD grant and linking to the researcher opening PDF.  
- Update `_projects/superalignment-task-decomposition.md` to acknowledge that the project is supported by a $100,000 USD grant from Coefficient Giving.  
- The news item links to the position PDF at `https://mai-alignment.github.io/assets/pdf/Research_Assistant_Position_E13_Bonn.pdf` and notes the 12-month researcher search.  
- No other content or formatting changes were made.

### Testing

- Ran `bundle install` to prepare the site dependencies and `bundle exec jekyll build`, and the site generation completed successfully albeit with warnings about ImageMagick `convert` missing.  
- Installed Playwright browsers and used `npx --yes playwright@latest screenshot` to capture full-page screenshots of the generated news and project pages, which completed and produced output files.  
- Confirmed the two modified files render in the generated site and verified the news post date and the added grant acknowledgement appeared on the project page.  
- All automated checks completed with success except the noted ImageMagick warnings (image conversion not available in the environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26a67110248322868751fb3b1c5263)